### PR TITLE
add using namespace

### DIFF
--- a/Custom Class For CocoStudio.xctemplate/___FILEBASENAME___.cpp
+++ b/Custom Class For CocoStudio.xctemplate/___FILEBASENAME___.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "___FILEBASENAME___.h"
+USING_NS_CC;
 
 #pragma mark - Public methods
 


### PR DESCRIPTION
CSLoaderは名前空間cocos2dに含まれるため、毎回cocos2d::を付け足す必要があったので、using宣言を追加しました。
